### PR TITLE
fix/rlay-client-lib: fix null dataPropertyAssertion bug

### DIFF
--- a/rlay-client-lib/src/entity/factory-interface.js
+++ b/rlay-client-lib/src/entity/factory-interface.js
@@ -30,9 +30,15 @@ const EntityFactoryInterface = Mixin((superclass) => class extends superclass {
   static prepareRlayFormat (params = {}) {
     const format = { };
     this.fields.forEach(field => {
-      format[field] = (
-        params[field] || (this.fieldsDefault || {})[field] || undefined
-      );
+      if (params[field] === undefined) {
+        if ((this.fieldsDefault || {})[field] === undefined) {
+          format[field] = undefined
+        } else {
+          format[field] = (this.fieldsDefault || {})[field]
+        }
+      } else {
+        format[field] = params[field]
+      }
     });
     format.type = this.type;
     return format;


### PR DESCRIPTION
This fixes the following bug:

```
{
  annotations: [],
  subject: '0x00',
  property: '0x019480031b207b421b9a7847780c9d76a9acc1ad96a5c6a8597a4b7acba7b2499bc1fa008225',
  target: undefined,
  type: 'DataPropertyAssertion'
}
```

when creating a `DataPropertyAssertion` with target value `null`